### PR TITLE
fix two issues of sandbox

### DIFF
--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -220,7 +220,12 @@ func (m *ShimManager) Start(ctx context.Context, id string, opts runtime.CreateO
 			return nil, err
 		}
 
-		shim, err := loadShim(ctx, bundle, func() {})
+		shim, err := loadShim(ctx, bundle, func() {
+			if err := bundle.Delete(); err != nil {
+				log.G(ctx).Errorf("failed to delete bundle %w", err)
+			}
+			m.shims.Delete(ctx, id)
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to load sandbox task %q: %w", opts.TaskAddress, err)
 		}


### PR DESCRIPTION
1. when recover the task and connecting to task, we need to add the onClose to make sure to delete the bundle after task disconnected
2. sandbox.Wait may fail if sandboxer restart, so we need to add a retry policy to make sure container will retry call wait after sandboxer restart.