### PR TITLE
Some bugfixes

### DIFF
--- a/pkg/cri/sbserver/events.go
+++ b/pkg/cri/sbserver/events.go
@@ -391,6 +391,14 @@ func handleContainerExit(ctx context.Context, e *eventtypes.TaskExit, cntr conta
 			}
 			// Move on to make sure container status is updated.
 		}
+
+		sandbox, err := c.sandboxStore.Get(sandboxID)
+		if err != nil {
+			return fmt.Errorf("failed to find sandbox id %q: %w", sandboxID, err)
+		}
+		if err := sandbox.SandboxInstance.Purge(ctx, cntr.ID, ""); err != nil {
+			return fmt.Errorf("failed to purge container %q: %w", cntr.ID, err)
+		}
 	}
 	err = cntr.Status.UpdateSync(func(status containerstore.Status) (containerstore.Status, error) {
 		if status.FinishedAt == 0 {

--- a/pkg/cri/sbserver/restart.go
+++ b/pkg/cri/sbserver/restart.go
@@ -143,6 +143,7 @@ func (c *criService) recover(ctx context.Context) error {
 			State:       state,
 			Pid:         status.Pid,
 			TaskAddress: status.TaskAddress,
+			CreatedAt:   status.CreatedAt,
 		})
 
 		// Load network namespace.

--- a/pkg/cri/sbserver/restart.go
+++ b/pkg/cri/sbserver/restart.go
@@ -133,6 +133,13 @@ func (c *criService) recover(ctx context.Context) error {
 			if code, ok := runtime.PodSandboxState_value[status.State]; ok {
 				if code == int32(runtime.PodSandboxState_SANDBOX_READY) {
 					state = sandboxstore.StateReady
+					exitCh, err := sbx.Wait(ctx)
+					if err != nil {
+						// Wait sandbox is not mandatory, if failed, we can still recover it.
+						log.G(ctx).WithError(err).Errorf("failed to wait sandbox %s", sbx.ID())
+					} else {
+						c.eventMonitor.startSandboxExitMonitor(ctx, sbx.ID(), status.Pid, exitCh)
+					}
 				} else if code == int32(runtime.PodSandboxState_SANDBOX_NOTREADY) {
 					state = sandboxstore.StateNotReady
 				}

--- a/runtime/v2/manager.go
+++ b/runtime/v2/manager.go
@@ -196,7 +196,9 @@ func (m *ShimManager) Start(ctx context.Context, id string, opts runtime.CreateO
 			Path:      opts.Bundle,
 			Namespace: ns,
 		}
-		if err := os.Symlink(opts.Bundle, filepath.Join(m.state, ns, id)); err != nil {
+		taskDir := filepath.Join(m.state, ns, id)
+		_ = os.MkdirAll(filepath.Dir(taskDir), 0755)
+		if err := os.Symlink(opts.Bundle, taskDir); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
1. Fix sandbox createTime and not find kuasar binary in loadShimTask 
2. Cleanup sandbox if it was failed to Start 
3. Create cri task dir before symlink its bundle 
4. Wait sandbox in recovery and purge container in handleContainerExit 

Signed-off-by: Zhang Tianyang <burning9699@gmail.com>